### PR TITLE
Add Fees + Staking to ChainInfo and Use latest chain-registry git sha

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -17,6 +17,8 @@ pub struct ChainInfo {
     pub codebase: Codebase,
     pub peers: Peers,
     pub apis: Apis,
+    pub fees: Fees,
+    pub staking: Staking,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -85,4 +87,33 @@ pub struct Rest {
 pub struct Grpc {
     pub address: String,
     pub provider: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Fees {
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    pub fee_tokens: Vec<FeeToken>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct FeeToken {
+    pub denom: String,
+    pub low_gas_price: f32,
+    pub average_gas_price: f32,
+    pub high_gas_price: f32,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Staking {
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
+    pub staking_tokens: Vec<StakingToken>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct StakingToken {
+    pub denom: String,
 }

--- a/src/get.rs
+++ b/src/get.rs
@@ -8,11 +8,10 @@ pub use crate::{assets::*, chain::*, paths::*};
 #[cfg(all(feature = "registry-cache"))]
 pub use self::cache::*;
 
-
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 // In the future we may want to provide a way for a user to set the desired ref for the registry
 // module to use when querying.
-const GIT_REF: &str = "d063b0fd6d1c20d6476880e5ea2212ade009f69e";
+const GIT_REF: &str = "350840e766f7574a120760a13eda4c466413308a";
 const RAW_FILE_REPO_URL: &str = "https://raw.githubusercontent.com/cosmos/chain-registry";
 const REPO_URL: &str = "https://api.github.com/repos/cosmos/chain-registry/contents";
 


### PR DESCRIPTION
These fields were missing:
https://github.com/cosmos/chain-registry/blob/master/juno/chain.json#L19-L35


I also bumped the git sha to point to the latest configs:
https://github.com/cosmos/chain-registry/commit/350840e766f7574a120760a13eda4c466413308a