### PR TITLE
Add Codebase dependency versions

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -45,6 +45,10 @@ pub struct Codebase {
     #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub compatible_versions: Vec<String>,
     pub binaries: Binaries,
+    pub cosmos_sdk_version: String,
+    pub tendermint_version: String,
+    pub cosmwasm_version: String,
+    pub cosmwasm_enabled: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]


### PR DESCRIPTION
Now that we added `deny_unknown_fields`, I found a few more missing fields:
- https://github.com/cosmos/chain-registry/blob/master/juno/chain.json#L42-L45